### PR TITLE
Add 1st Level spell to spell list - legacy

### DIFF
--- a/client/homebrew/editor/snippetbar/snippetsLegacy/magic.gen.js
+++ b/client/homebrew/editor/snippetbar/snippetsLegacy/magic.gen.js
@@ -51,7 +51,7 @@ const spellNames = [
 module.exports = {
 
 	spellList : function(){
-		const levels = ['Cantrips (0 Level)', '2nd Level', '3rd Level', '4th Level', '5th Level', '6th Level', '7th Level', '8th Level', '9th Level'];
+		const levels = ['Cantrips (0 Level)', '1st Level', '2nd Level', '3rd Level', '4th Level', '5th Level', '6th Level', '7th Level', '8th Level', '9th Level'];
 
 		const content = _.map(levels, (level)=>{
 			const spells = _.map(_.sampleSize(spellNames, _.random(5, 15)), (spell)=>{


### PR DESCRIPTION
Should have been included on #1479/#1480, which updated v3 Spell List snippet, but forgot about the snippet in Legacy.  This corrects that oversight, to finish out #1274.